### PR TITLE
Update web flasher with new firmwares

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,17 +27,17 @@
       </div>
     </div>
     <h1 class="text-center mb-5">UTF-8 SAMPLIFIED FLASHER</h1>
-    <p>This page allows easy (re-)flashing of your arduino nano or nano clone with different exitsting firmwares for the utf-8 samplified module. you must use google chrome in order for the flasher to work since the used js-lib doesnt allow to use safari. make sure to choose the correct board.</p>
+    <p>This page allows easy (re-)flashing of your arduino nano or nano clone with different existing firmwares for the utf-8 samplified module. you must use google chrome in order for the flasher to work since the used js-lib doesn't allow to use safari. Make sure to choose the correct board.</p>
     <br>
     <div class="row justify-content-center">
-      <div class="col-12 col-md-4">
+      <div class="col-12 col-md-2">
         <h4 class="text-center mb-5">MATTEL</h4>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./mattel.ino.eightanaloginputs.hex" board="nano">
           Nano
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./mattel.ino.eightanaloginputs.hex" board="nanoOldBootloader">
-          Nano with Old Bootloader
+          Nano w/ Old Bootloader
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100" arduino-uploader hex-href="./mattel.ino.eightanaloginputs.hex" board="lgt8f328p">
@@ -45,14 +45,14 @@
           <span class="upload-progress"></span>
         </button>
       </div>
-      <div class="col-12 col-md-4">
+      <div class="col-12 col-md-2">
         <h4 class="text-center mb-5">DEFAULT</h4>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./standard.ino.eightanaloginputs.hex" board="nano">
           Nano
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./standard.ino.eightanaloginputs.hex" board="nanoOldBootloader">
-          Nano with Old Bootloader
+          Nano w/ Old Bootloader
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100" arduino-uploader hex-href="./standard.ino.eightanaloginputs.hex" board="lgt8f328p">
@@ -60,17 +60,62 @@
           <span class="upload-progress"></span>
         </button>
       </div>
-      <div class="col-12 col-md-4">
+      <div class="col-12 col-md-2">
         <h4 class="text-center mb-5">LATIN</h4>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./latin.ino.eightanaloginputs.hex" board="nano">
           Nano
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./latin.ino.eightanaloginputs.hex" board="nanoOldBootloader">
-          Nano with Old Bootloader
+          Nano w/ Old Bootloader
           <span class="upload-progress"></span>
         </button>
         <button class="btn btn-success w-100" arduino-uploader hex-href="./latin.ino.eightanaloginputs.hex" board="lgt8f328p">
+          LGT8F328P
+          <span class="upload-progress"></span>
+        </button>
+      </div>
+      <div class="col-12 col-md-2">
+        <h4 class="text-center mb-5">808</h4>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./808.hex" board="nano">
+          Nano
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./808.hex" board="nanoOldBootloader">
+          Nano w/ Old Bootloader
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100" arduino-uploader hex-href="./808.hex" board="lgt8f328p">
+          LGT8F328P
+          <span class="upload-progress"></span>
+        </button>
+      </div>
+      <div class="col-12 col-md-2">
+        <h4 class="text-center mb-5">BEATBOX</h4>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./beatbox.hex" board="nano">
+          Nano
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./beatbox.hex" board="nanoOldBootloader">
+          Nano w/ Old Bootloader
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100" arduino-uploader hex-href="./beatbox.hex" board="lgt8f328p">
+          LGT8F328P
+          <span class="upload-progress"></span>
+        </button>
+      </div>
+      <div class="col-12 col-md-2">
+        <h4 class="text-center mb-5">JUNGLE</h4>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./jungle.hex" board="nano">
+          Nano
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100 mb-3" arduino-uploader hex-href="./jungle.hex" board="nanoOldBootloader">
+          Nano w/ Old Bootloader
+          <span class="upload-progress"></span>
+        </button>
+        <button class="btn btn-success w-100" arduino-uploader hex-href="./jungle.hex" board="lgt8f328p">
           LGT8F328P
           <span class="upload-progress"></span>
         </button>


### PR DESCRIPTION
This PR extends the web flare for the ute-8-samplified module with the new firmwares from https://github.com/wgd-modular/utf-8-samplified/pull/2

@poetaster Would be awesome if you could push the corresponding hex files (`808.hex`, `jungle.hex` and `beatbox.hex`) to this branch. Root directory of the repo would work with the currently set paths in the index.html file.